### PR TITLE
프로필 페이지 돌아가게 하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules/
 .DS_STORE
 *.log
 bower_components/
-
+webapp/public/peoples/
 
 # MAC DS_STORE
 **/.DS_Store

--- a/webapp/public/img_upload_popup.html
+++ b/webapp/public/img_upload_popup.html
@@ -10,9 +10,10 @@
     <title>이미지 전송</title>
 </head>
 <body>
-    <form method="get" action="/img_upload_popup_response.html"  enctype="multipart/form-data" name="uploadform">
-        <input type="file" name="imagefile" id="imagefile">
+    <form method="post" action="/profile/photo"  enctype="multipart/form-data" name="uploadform">
+        <input type="file" name="imagefile" id="imagefile"  onchange="handleFiles(this.files)">
     </form>
+    <div class="preview"></div>
     <button>확인</button>
     <script>
         $("button").on("click", $.proxy(function(){
@@ -21,6 +22,44 @@
 //            self.close();
         }, this));
 
+    </script>
+    <script>
+    (function() {
+        var inputElement = document.querySelector("#imagefile");
+        inputElement.addEventListener("change", handleFiles, false);
+    })();
+
+    function handleFiles(files) {
+        var preview = document.querySelector(".preview");
+        if(files.length === 0) {
+            preview.innerHTML = "";
+            return;
+        }
+        
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
+            var imageType = /image.*/;
+
+            if (!file.type.match(imageType)) {
+                continue;
+            }
+
+            var img = document.createElement("img");
+            img.classList.add("attachedImg");
+            img.height = 200;
+            img.file = file;
+            preview.innerHTML="";
+            preview.appendChild(img); // Assuming that "preview" is the div output where the content will be displayed.
+            
+            var reader = new FileReader();
+            reader.onload = (function(aImg) {
+                return function(e) {
+                    aImg.src = e.target.result;
+                };
+            })(img);
+            reader.readAsDataURL(file);
+        }
+    }
     </script>
 </body>
 

--- a/webapp/views/profile.ejs
+++ b/webapp/views/profile.ejs
@@ -23,37 +23,58 @@
 <body>
     <header>
     </header>
-
     <div id="wrapper">
         <!-- 개인 프로필 정보 -->
-        <section id="core_info">
-            <form action="/profile">
-                <!-- 사진업로드 -->
-                <input class="fileupload" type="button" name="photourl" value="프로필 사진 업로드"/>
+        <div class="col-sm-6 col-sm-offset-3">
 
-                <!-- 사진미리보기 -->
-                <style>
-                    .preview {
-                        width : 500px;
-                    }
-                    .preview .fit{
-                        width : 100%;
-                    }
+        <section id="core_info" class="respond-form">
+            <form class="form-horizontal" role="form" action="#">
+            <div class="form-group">
+                <label for="moto" class="col-sm-2 control-label">선언문</label>
+                <div class="col-sm-10">
+                    <input type="text" class="form-control" id="moto" name="moto" placeholder="선언문" value="">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="movieurl" class="col-sm-2 control-label">movie url</label>
+                <div class="col-sm-10">
+                    <input type="movieurl" class="form-control" id="movieurl" name="movieurl" placeholder="유투브 주소" value="">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="markdown" class="col-sm-2 control-label">자기소개</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="markdown" rows="10" name="markdown" placeholder="마크다운으로 자기소개를 작성해주세요."></textarea>
+                </div>
+            </div>
+            
+            <div class="form-group">
+                <label for="photourl" class="col-sm-2 control-label">프로필 사진</label>
+                <div class="col-sm-10 col-sm-offset-2">
+                    <input class="imageInput fileupload form-control" type="button" name="photourl" accept="image/*" value="프로필 사진 업로드"/>
+                    <div class="preview"></div>
+                </div>
+            </div>
 
-                </style>
-                <div class="preview"></div>
+            <div class="form-group">
+                <div class="col-sm-10 col-sm-offset-2">
+                    <button id="submit" name="submit" type="submit" value="Send" class="btn btn-primary">send</button>
+                </div>
+            </div>
 
-                <!-- 선언문 -->
-                <input type="text" name="moto" placeholder= "선언문" />
-                <!--동영상링크-->
-                <input type="text" name="movieurl" placeholder="유투브 동영상 주소" >              
+            <div class="form-group">
+                <div class="col-sm-10 col-sm-offset-2">
+                    <! Will be used to display an alert to the user>
+                </div>
+            </div>
+        </form>
 
-                <!--마크다운-->
-                <textarea name="markdown" placeholder="마크다운"></textarea>
-                <input class="profileupload" type="button" value="등록">
-            </form>
+
+
+
         </section>
-        <!-- //개인 프로필 정보 -->
+    </div>
+    <!-- //개인 프로필 정보 -->
     </div>
     <footer></footer>
 
@@ -61,102 +82,39 @@
         var dataObject = <%-JSON.stringify(user) %>;
 
         var htInitData = {
-            userId : dataObject._id,
-            photourl : dataObject.profile.photourl,
-            moto : dataObject.profile.moto,
-            movieurl: dataObject.profile.movieurl,
-            markdown : dataObject.profile.markdown
+                //userId : dataObject._id,
+                photourl : dataObject.profile.photourl,
+                moto : dataObject.profile.moto,
+                movieurl: dataObject.profile.movieurl,
+                markdown : dataObject.profile.markdown  
         }
-    </script>
 
-    <script>
-
-        var ImagePreview = function(ht){
-            this.init(ht);
-        };
-
-        ImagePreview.prototype = {
-            init : function(ht){
-                this.$elFileUpload = $(ht.elFileUpload);
-                this.$elPreview = $(ht.elPreview);
-
-                this.$elFileUpload.on("click", $.proxy(this._onClickFileUpload, this));
-                // this.$elFileUpload.on("change", $.proxy(this._onChangeFileUpload, this));
+        var profileHelper = {
+            init: function(ht){
+                this._initComponent();
+                this._fillData(); 
+                this.$elFileUpload.addEventListener("click", $.proxy(this._onClickFileUpload, this));
+                this.$elProfileUpdateBtn.addEventListener("click", function(){
+                    $.ajax({
+                        url: "/profile",
+                        type: "PUT",
+                        data: $('#core_info form').serialize(),
+                    }).success(function() {
+                        alert("정상적으로 업로드되었습니다.");
+                    });
+                })
             },
 
             _onClickFileUpload : function(e){
                 console.log("open");
-                window.open("/img_upload_popup.html", "이미지 업로드", "fullscreen=no, width=200, height=200");
+                window.open("/img_upload_popup.html", "이미지 업로드", "fullscreen=no, width=500, height=500");
             },
 
-            //https://jsfiddle.net/0GiS0/Yvgc2/
-            _onChangeFileUpload : function(evt){
-                var oInput = evt.target.files[0];
-                var isNotImage = !oInput.type.match(/^image/);
-
-                if(isNotImage){
-                    alert("이미지 파일만 업로드 해주세요.");
-                    return ;
-                }
-
-                var oReader = new FileReader();
-                $(oReader).on("load", $.proxy(function(e){
-                    var oImageFile = e.target;
-                    var sDataUrl = oImageFile.result;
-                    this._createCanvasImage(sDataUrl);
-                }, this));
-                oReader.readAsDataURL(oInput);
-            },
-
-            _createCanvasImage : function(sDataUrl){
-                var elImage = new Image();
-                elImage.src = sDataUrl;
-                var width = elImage.width;
-                var height = elImage.height;
-
-                elImage.onload = $.proxy(function(){
-                    this.$elPreview.html("");
-                    var elCanvas = document.createElement("canvas");
-                    elCanvas.width = width;
-                    elCanvas.height = height;
-                    var ctx = elCanvas.getContext("2d");
-
-                    ctx.drawImage(elImage,0,0, width, height, 0, 0, width, height);
-                    this.$elPreview.append(elCanvas);
-                    this.$elPreview.find("canvas").addClass("fit")
-                }, this);
-            }
-        };
-
-        var ProfileUpdate = function(ht){
-            this.init(ht);
-        };
-
-        ProfileUpdate.prototype = {
-            init : function(ht){
-                this.option = ht;
-                this.$elRoot = $(ht.elRoot);
-                this.$elButton = $(ht.elButton);
-                this._initComponent();
-                this._fillData();
-                this.$elButton.on("click", $.proxy(function(){
-                    console.log("profile upload button clicked");
-                    $.ajax({
-                      type: "PUT",
-                      url: "/profile",
-                      data: $('#core_info form').serialize(),
-                      success: function(data, textStatus, jqXHR) {
-                        alert('everything was OK');
-                      }
-                    });
-                }));
-            },
-
-            _initComponent : function(){
-                new ImagePreview({
-                    elFileUpload : $(".fileupload"),
-                    elPreview : $(".preview")
-                });
+            _initComponent: function() {
+                this.$elRoot = document.querySelector("#core_info");
+                this.$elProfileUpdateBtn = this.$elRoot.querySelector("#submit");
+                this.$elPreview = this.$elRoot.querySelector(".preview");
+                this.$elFileUpload = this.$elRoot.querySelector(".imageInput");
             },
 
             _fillData : function(){
@@ -166,37 +124,100 @@
                     return ;
                 }
                 for (var i in htData){
-                    var input = this.$elRoot.find("[name=" + i + "]");
+                    var input = this.$elRoot.querySelector("#"+i);
                     if(i === "photourl"){
                         this._fillProfileImage(htData[i]);
                     } else {
-                        input.val(htData[i]);
+                        input.value = htData[i];
                     }
                 }
             },
 
             _fillProfileImage : function(imgUrl){
-                var $preview = this.$elRoot.find(".preview");
+                var $preview = this.$elPreview;
                 console.log(imgUrl);
-                $preview.html("<img class='fit' src=" + imgUrl + ">");
+                $preview.innerHTML = "<img class='fit' src=" + imgUrl + " height='200' >";
+            },
+
+            _getFormData: function(){
+                var form = $('form')[0];
+                return new FormData(form);
             }
+
+
         };
 
-        /*
-            profilePhoto
-            declaration
-            youtubeVid
-            markdownText
-        */
-        new ProfileUpdate({
-            elRoot : $("#wrapper").get(0),
-            elButton : $(".profileupload").get(0)
-//            htInitData : htInitData
+        $(document).ready(function () {
+            profileHelper.init(htInitData);
         });
+    </script>
+    <script>
+    //     var ImagePreview = function(ht){
+    //         this.init(ht);
+    //     };
 
-        function onSavedProfileImage(sFilePath){
-            alert(sFilePath);
-        }
+    //     ImagePreview.prototype = {
+    //         init : function(ht){
+    //             this.$elFileUpload = $(ht.elFileUpload);
+    //             this.$elPreview = $(ht.elPreview);
+    //             // this.$elFileUpload.on("change", $.proxy(this._onChangeFileUpload, this));
+    //         },
+
+    //     var ProfileUpdate = function(ht){
+    //         this.init(ht);
+    //     };
+
+    //     ProfileUpdate.prototype = {
+    //         init : function(ht){
+    //             this.option = ht;
+    //             this.$elRoot = $(ht.elRoot);
+    //             this.$elButton = $(ht.elButton);
+    //             this._initComponent();
+    //             this._fillData();
+    //             this.$elButton.on("click", $.proxy(function(){
+    //                 console.log("profile upload button clicked");
+    //                 $.ajax({
+    //                   type: "PUT",
+    //                   url: "/profile",
+    //                   data: $('#core_info form').serialize(),
+    //                   success: function(data, textStatus, jqXHR) {
+    //                     alert('everything was OK');
+    //                   }
+    //                 });
+    //             }));
+    //         },
+
+    //         _initComponent : function(){
+    //             new ImagePreview({
+    //                 elFileUpload : $(".fileupload"),
+    //                 elPreview : $(".preview")
+    //             });
+    //         },
+
+    //         _fillData : function(){
+    //             var htData = htInitData;
+    //             if(!htData){
+    //                 // 초기 사용자 데이터 없음
+    //                 return ;
+    //             }
+    //             for (var i in htData){
+    //                 var input = this.$elRoot.find("[name=" + i + "]");
+    //                 if(i === "photourl"){
+    //                     this._fillProfileImage(htData[i]);
+    //                 } else {
+    //                     input.val(htData[i]);
+    //                 }
+    //             }
+    //         },
+
+    //         _fillProfileImage : function(imgUrl){
+    //             var $preview = this.$elRoot.find(".preview");
+    //             console.log(imgUrl);
+    //             $preview.html("<img class='fit' src=" + imgUrl + ">");
+    //         }
+    //     };
+
+    // 
     </script>
 </body>
 </html>


### PR DESCRIPTION
- redesign with bootstrap
- 이미지 올릴 때, 팝업창에서 확인을 누르면 사진이 서버에 추가되면서 user 정보가 이미 업데이트 된다.
- 팝업창의 확인버튼을 누른 후 사용자는 팝업 윈도우를 끄고, 메인 화면에서 text box를 수정하여 send 버튼을 누르면 기능은 잘 동작한다.
- 자연스러운 UX를 위해 이미 등록 팝업창이 자동으로 꺼지는 것, 팝업창으로 부터 받은 response가 main에 추가되는 것이 아직 남아있다. 
